### PR TITLE
Set type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ matrix:
 script:
     - cargo build
     - cargo test
+notifications:
+    email: false

--- a/src/graphite.rs
+++ b/src/graphite.rs
@@ -16,6 +16,7 @@ use cache::CapellaCache;
 
 const CAPELLA_METRICS_TOTAL: &'static str = "capella.total_metrics";
 const CAPELLA_BAD_METRICS_TOTAL: &'static str = "capella.bad_metrics";
+const COUNT_SUFFIX: &'static str = ".count";
 
 /// The backend to a graphite server.
 #[derive(Debug)]
@@ -66,6 +67,13 @@ impl Backend for Graphite {
 
         for (k, v) in cache.timer_data_iter() {
             let metric_str = self.make_metric_string(k, v, &unix_time);
+            buffer.push_str(&metric_str);
+        }
+
+        for (k, v) in cache.sets_iter() {
+            let key = String::from(&*k.clone().as_str()) + COUNT_SUFFIX;
+            let value = v.len() as f64;
+            let metric_str = self.make_metric_string(&key, &value, &unix_time);
             buffer.push_str(&metric_str);
         }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -12,8 +12,7 @@ use error::{Error, CapellaResult};
 pub enum MetricType {
     Counter,
     Gauge,
-    Histogram,
-    Meter,
+    Set,
     Timer,
 }
 
@@ -24,9 +23,8 @@ impl FromStr for MetricType {
         match s {
             "c" => Ok(MetricType::Counter),
             "g" => Ok(MetricType::Gauge),
-            "h" => Ok(MetricType::Histogram),
-            "m" => Ok(MetricType::Meter),
             "ms" => Ok(MetricType::Timer),
+            "s" => Ok(MetricType::Set),
             _ => Err(Error::Parse),
         }
     }
@@ -46,7 +44,7 @@ impl Metric {
         Metric {
             name: Rc::new(String::new()),
             value: 0.0,
-            metric_type: MetricType::Meter,
+            metric_type: MetricType::Counter,
             sample_rate: None,
         }
     }
@@ -125,8 +123,8 @@ mod tests {
     }
 
     #[test]
-    fn good_simple_meter() {
-        let packet = b"test:1|m";
+    fn good_simple_counter() {
+        let packet = b"test:1|c";
         let m1 = parse_metric(packet).unwrap();
 
         let mut m2 = Metric::new();


### PR DESCRIPTION
After rereading the StatsD metric type README, I have added the set metric type and removed extraneous types.

Since rust's `HashSet` only supports types that implement `PartialEq`, all values are converted to `i64`. Then a count metric is forwarded to graphite.